### PR TITLE
Fixed num_permitted_opens not enough caused request denied

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -3027,7 +3027,7 @@ channel_connect_to(const char *host, u_short port, char *ctype, char *rname)
 				permit_adm = 1;
 	}
 
-	if (!permit || !permit_adm) {
+	if (!permit && !permit_adm) {
 		logit("Received request to connect to host %.100s port %d, "
 		    "but the request was denied.", host, port);
 		return NULL;


### PR DESCRIPTION
i think num_permitted_opens and num_adm_permitted_opens are both variable used to set valid number be opened by each channel.

ANY of them is not zero, we should create a connect for them. 

So the condition in the code `!permit || !permit_adm` should be replaced by `!permit && !permit_adm`
